### PR TITLE
cacheをAPIに効かせる(searchChairs) 

### DIFF
--- a/isuumo/webapp/go/main.go
+++ b/isuumo/webapp/go/main.go
@@ -614,11 +614,18 @@ func searchChairs(c echo.Context) error {
 	searchCondition := strings.Join(conditions, " AND ")
 	limitOffset := " ORDER BY popularity_reversed, id ASC LIMIT ? OFFSET ?"
 
+	var cacheKey = "searchChairs"
 	var res ChairSearchResponse
-	err = dbChair.Get(&res.Count, countQuery+searchCondition, params...)
-	if err != nil {
-		c.Logger().Errorf("searchChairs DB execution error : %v", err)
-		return c.NoContent(http.StatusInternalServerError)
+	v, found := chairCacheManager.Get(cacheKey + "count")
+	if found {
+		res.Count = v.(int64)
+	} else {
+		err = dbChair.Get(&res.Count, countQuery+searchCondition, params...)
+		if err != nil {
+			c.Logger().Errorf("searchChairs DB execution error : %v", err)
+			return c.NoContent(http.StatusInternalServerError)
+		}
+		chairCacheManager.Set(cacheKey+"count", res.Count, gocache.DefaultExpiration)
 	}
 
 	chairs := []Chair{}

--- a/isuumo/webapp/go/main.go
+++ b/isuumo/webapp/go/main.go
@@ -407,6 +407,8 @@ func initialize(c echo.Context) error {
 		}
 	}
 
+	chairCacheManager.Flush()
+	estateCacheManager.Flush()
 	return c.JSON(http.StatusOK, InitializeResponse{
 		Language: "go",
 	})

--- a/isuumo/webapp/go/main.go
+++ b/isuumo/webapp/go/main.go
@@ -616,7 +616,7 @@ func searchChairs(c echo.Context) error {
 
 	var cacheKey = "searchChairs"
 	var res ChairSearchResponse
-	v, found := chairCacheManager.Get(cacheKey + "count")
+	v, found := chairCacheManager.Get(cacheKey + "count" + fmt.Sprintln(params))
 	if found {
 		res.Count = v.(int64)
 	} else {
@@ -625,7 +625,7 @@ func searchChairs(c echo.Context) error {
 			c.Logger().Errorf("searchChairs DB execution error : %v", err)
 			return c.NoContent(http.StatusInternalServerError)
 		}
-		chairCacheManager.Set(cacheKey+"count", res.Count, gocache.DefaultExpiration)
+		chairCacheManager.Set(cacheKey+"count"+fmt.Sprintln(params), res.Count, gocache.DefaultExpiration)
 	}
 
 	chairs := []Chair{}


### PR DESCRIPTION
related: #15 

# feat: flush cache at init funcまで
cf41a07471ffadc7c6afebb748ce5a67f19edb7b まで

```
{"pass":true,"score":6447,"messages":[],"reason":"OK","language":"go"}
```